### PR TITLE
don't use undefined :or-destructuring behavior

### DIFF
--- a/src/ring/middleware/format_params.clj
+++ b/src/ring/middleware/format_params.clj
@@ -214,12 +214,11 @@
   [handler & {:keys [predicate decoder charset binary? handle-error options]
               :or {predicate transit-json-request?
                    options {}
-                   decoder (make-transit-decoder :json options)
                    binary? true
                    handle-error default-handle-error}}]
   (wrap-format-params handler
                       :predicate predicate
-                      :decoder decoder
+                      :decoder (or decoder (make-transit-decoder :json options))
                       :binary? binary?
                       :handle-error handle-error))
 
@@ -232,12 +231,11 @@
   [handler & {:keys [predicate decoder charset binary? handle-error options]
               :or {predicate transit-msgpack-request?
                    options {}
-                   decoder (make-transit-decoder :msgpack options)
                    binary? true
                    handle-error default-handle-error}}]
   (wrap-format-params handler
                       :predicate predicate
-                      :decoder decoder
+                      :decoder (or decoder (make-transit-decoder :msgpack options))
                       :binary? binary?
                       :handle-error handle-error))
 

--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -201,17 +201,19 @@
   [handler & {:keys [predicate encoder type charset handle-error pretty]
               :or {predicate serializable?
                    pretty nil
-                   encoder (if pretty
-                             (fn [s] (json/generate-string s {:pretty pretty}))
-                             json/generate-string)
                    type "application/json"
                    charset default-charset-extractor
                    handle-error default-handle-error}}]
-  (wrap-format-response handler
-                        :predicate predicate
-                        :encoders [(make-encoder encoder type)]
-                        :charset charset
-                        :handle-error handle-error))
+  (let [encoder (or
+                  encoder
+                  (if pretty
+                    (fn [s] (json/generate-string s {:pretty pretty}))
+                    json/generate-string))]
+    (wrap-format-response handler
+                          :predicate predicate
+                          :encoders [(make-encoder encoder type)]
+                          :charset charset
+                          :handle-error handle-error)))
 
 ;; Functions for Clojure native serialization
 
@@ -303,28 +305,28 @@
   See [[wrap-format-response]] for more details."
   [handler & {:keys [predicate encoder type handle-error options]
               :or {predicate serializable?
-                   encoder (make-transit-encoder :json options)
                    type "application/transit+json"
                    handle-error default-handle-error}}]
-  (wrap-format-response handler
-                        :predicate predicate
-                        :encoders [(make-encoder encoder type :binary)]
-                        :charset nil
-                        :handle-error handle-error))
+  (let [encoder (or encoder (make-transit-encoder :json options))]
+    (wrap-format-response handler
+                          :predicate predicate
+                          :encoders [(make-encoder encoder type :binary)]
+                          :charset nil
+                          :handle-error handle-error)))
 
 (defn wrap-transit-msgpack-response
   "Wrapper to serialize structures in *:body* to transit over **msgpack** with sane defaults.
   See [[wrap-format-response]] for more details."
   [handler & {:keys [predicate encoder type handle-error options]
               :or {predicate serializable?
-                   encoder (make-transit-encoder :msgpack options)
                    type "application/transit+msgpack"
                    handle-error default-handle-error}}]
-  (wrap-format-response handler
-                        :predicate predicate
-                        :encoders [(make-encoder encoder type :binary)]
-                        :charset nil
-                        :handle-error handle-error))
+  (let [encoder (or encoder (make-transit-encoder :msgpack options))]
+    (wrap-format-response handler
+                          :predicate predicate
+                          :encoders [(make-encoder encoder type :binary)]
+                          :charset nil
+                          :handle-error handle-error)))
 
 (def ^:no-doc format-encoders
   {:json (make-encoder json/generate-string "application/json")


### PR DESCRIPTION
The fact that one :or-param can predictably refer to another is
_extremely_ brittle -- it only works because maps in the code become
PersistentArrayMaps and they have a specific seq order relative to the
order keys are assoced in. With a different map implementation, or with
enough keys to spill over to a PersistentHashMap, this explodes.

http://dev.clojure.org/jira/browse/CLJ-1613

(Copied original PR by MichaelBlume)
