### PR TITLE
Add content-type to encoders for introspection

### DIFF
--- a/src/ring/middleware/format_response.clj
+++ b/src/ring/middleware/format_response.clj
@@ -128,7 +128,9 @@
   ([encoder content-type binary?]
      {:encoder encoder
       :enc-type (first (parse-accept-header content-type))
-      :binary? binary?})
+      :binary? binary?
+      ;; Include content-type to allow later introspection of encoders.
+      :content-type content-type})
   ([encoder content-type]
      (make-encoder encoder content-type false)))
 


### PR DESCRIPTION
This makes encoders more declarative, which makes them easier to work
with programmatically.