### PR TITLE
Correct example code in README that is no longer valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mostly). If a route returns a _String_, _File_, _InputStream_ or _nil_, nothing 
 
 Please note the default JSON and YAML decoder do not keywordize their output keys, if this is the behaviour you want (be careful about keywordizing user input!), you should use something like:
 ```clojure
-(wrap-restful-format handler :formats [:json-kw :edn :yaml-kw :yaml-in-html :transit-json :transit-msgpack])
+(wrap-restful-format handler {:formats [:json-kw :edn :yaml-kw :yaml-in-html :transit-json :transit-msgpack]})
 ```
 
 See also [wrap-restful-format](http://metosin.github.com/ring-middleware-format/ring.middleware.format.html#var-wrap-restful-format) docstring for help on customizing error handling.


### PR DESCRIPTION
An example code in README looks as if it is saying that `r.m.format/wrap-restful-format` takes one mandatory argument and some keyword arguments, though it actually takes an argument and an optional map. This PR corrects the example.

Also, the entry for that function in the API document should be updated as well.